### PR TITLE
Fix #1174 - Exclude optional artifact from storm-hdfs

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -348,7 +348,6 @@ List of third-party dependencies grouped by their license type.
         * SparseBitSet (com.zaxxer:SparseBitSet:1.2 - https://github.com/brettwooldridge/SparseBitSet)
         * storm-autocreds (org.apache.storm:storm-autocreds:2.6.1 - https://storm.apache.org/external/storm-autocreds)
         * Storm Client (org.apache.storm:storm-client:2.6.1 - https://storm.apache.org/storm-client)
-        * storm-crawler-core (com.digitalpebble.stormcrawler:storm-crawler-core:2.12-SNAPSHOT - https://github.com/DigitalPebble/storm-crawler/tree/master/core)
         * storm-hdfs (org.apache.storm:storm-hdfs:2.6.1 - https://storm.apache.org/external/storm-hdfs)
         * swagger-annotations-jakarta (io.swagger.core.v3:swagger-annotations-jakarta:2.2.17 - https://github.com/swagger-api/swagger-core/modules/swagger-annotations-jakarta)
         * TagSoup (org.ccil.cowan.tagsoup:tagsoup:1.2.1 - http://home.ccil.org/~cowan/XML/tagsoup/)

--- a/external/warc/pom.xml
+++ b/external/warc/pom.xml
@@ -53,6 +53,11 @@
 					<groupId>org.apache.hive.hcatalog</groupId>
 					<artifactId>hive-hcatalog-streaming</artifactId>
 				</exclusion>
+				<!-- this is only needed if explicitly configured and will be dropped in 2.6.2 -->
+				<exclusion>
+					<groupId>io.confluent</groupId>
+					<artifactId>kafka-avro-serializer</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
Parts of this dependency cannot be resolved, because the related maven repository doesn't have a valid SSL/TLS certifacte anymore. As it is an optional dependency (from the storm perspective) and also not used inside of SC, we can just exclude it.

It is also removed in upcoming Storm 2.6.2