### PR TITLE
#626: Add routing field in metadata - Solr StatusUpdaterBolt

### DIFF
--- a/external/solr/cores/status/conf/schema.xml
+++ b/external/solr/cores/status/conf/schema.xml
@@ -25,5 +25,6 @@ under the License.
 	<field name="status" type="string" indexed="true" stored="true" required="true"/>
 	<field name="nextFetchDate" type="pdate" stored="true" indexed="true"/>
 	<dynamicField name="metadata*" type="string" indexed="true" stored="true" multiValued="true"/>
+	<field name="key" type="string" stored="true" indexed="true"/>
 	<uniqueKey>url</uniqueKey>
 </schema>

--- a/external/solr/cores/status/conf/schema.xml
+++ b/external/solr/cores/status/conf/schema.xml
@@ -26,5 +26,6 @@ under the License.
 	<field name="nextFetchDate" type="pdate" stored="true" indexed="true"/>
 	<dynamicField name="metadata*" type="string" indexed="true" stored="true" multiValued="true"/>
 	<field name="key" type="string" stored="true" indexed="true"/>
+	<dynamicField name="*" type="string" indexed="true" stored="true" multiValued="false"/>
 	<uniqueKey>url</uniqueKey>
 </schema>

--- a/external/solr/cores/status/conf/schema.xml
+++ b/external/solr/cores/status/conf/schema.xml
@@ -25,7 +25,7 @@ under the License.
 	<field name="status" type="string" indexed="true" stored="true" required="true"/>
 	<field name="nextFetchDate" type="pdate" stored="true" indexed="true"/>
 	<dynamicField name="metadata*" type="string" indexed="true" stored="true" multiValued="true"/>
-	<field name="key" type="string" stored="true" indexed="true"/>
+	<field name="key" type="string" stored="true" indexed="true" multiValued="false"/>
 	<dynamicField name="*" type="string" indexed="true" stored="true" multiValued="false"/>
 	<uniqueKey>url</uniqueKey>
 </schema>

--- a/external/solr/solr-conf.yaml
+++ b/external/solr/solr-conf.yaml
@@ -26,10 +26,7 @@ config:
   solr.status.max.results: 10
 
   # the routing is done on the value of 'partition.url.mode'
-  solr.status.routing: true
   # stores the value used for grouping the URLs as a separate field
-  # needed by the spout implementations
-  # also used for routing if the value above is set to true
   solr.status.routing.fieldname: "key"
 
   # time in secs for which the URLs will be considered for fetching after a ack or fail

--- a/external/solr/solr-conf.yaml
+++ b/external/solr/solr-conf.yaml
@@ -24,7 +24,14 @@ config:
   solr.status.bucket.maxsize: 5
   solr.status.metadata.prefix: metadata
   solr.status.max.results: 10
-  
+
+  # the routing is done on the value of 'partition.url.mode'
+  solr.status.routing: true
+  # stores the value used for grouping the URLs as a separate field
+  # needed by the spout implementations
+  # also used for routing if the value above is set to true
+  solr.status.routing.fieldname: "key"
+
   # time in secs for which the URLs will be considered for fetching after a ack or fail
   spout.ttl.purgatory: 30
   

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/Constants.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/Constants.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.stormcrawler.solr;
+
+public interface Constants {
+
+    String PARAMPREFIX = "solr.";
+}

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/StatusUpdaterBolt.java
@@ -46,7 +46,6 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     private static final String SolrMetadataPrefix = "solr.status.metadata.prefix";
 
-    private static final String SolrStatusRoutingParamName = Constants.PARAMPREFIX + "%s.routing";
     private static final String SolrStatusRoutingFieldParamName =
             Constants.PARAMPREFIX + "%s.routing.fieldname";
 

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/StatusUpdaterBolt.java
@@ -52,9 +52,6 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
     private URLPartitioner partitioner;
 
-    /** whether to apply the same partitioning logic used for politeness for routing, e.g byHost */
-    private boolean doRouting;
-
     /** Store the key used for routing explicitly as a field in metadata * */
     private String fieldNameForRoutingKey = null;
 
@@ -69,15 +66,6 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
         super.prepare(stormConf, context, collector);
 
         mdPrefix = ConfUtils.getString(stormConf, SolrMetadataPrefix, "metadata");
-
-        doRouting =
-                ConfUtils.getBoolean(
-                        stormConf,
-                        String.format(
-                                Locale.ROOT,
-                                StatusUpdaterBolt.SolrStatusRoutingParamName,
-                                BOLT_TYPE),
-                        false);
 
         partitioner = new URLPartitioner();
         partitioner.configure(stormConf);


### PR DESCRIPTION
#626 Now one can specify a routing key, which is added to the status metadata.