### PR TITLE
Bump Apache Storm from 3.1.1 to 2.6.4 & archetype 3.0 to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Apache StormCrawler (Incubating) is an open source collection of resources for b
 
 ## Quickstart
 
-NOTE: These instructions assume that you have [Apache Maven](https://maven.apache.org/install.html) installed. You will need to install [Apache Storm 3.1.1](http://storm.apache.org/) to run the crawler.
+NOTE: These instructions assume that you have [Apache Maven](https://maven.apache.org/install.html) installed. You will need to install [Apache Storm 2.6.4](http://storm.apache.org/) to run the crawler.
 
 StormCrawler requires Java 11 or above. To execute tests, it requires you to have a locally installed and working Docker environment.
 
@@ -18,7 +18,7 @@ DigitalPebble's [Ansible-Storm](https://github.com/DigitalPebble/ansible-storm) 
 Once Storm is installed, the easiest way to get started is to generate a new StormCrawler project following the instructions below: 
 
 ```shell
-mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-archetype -DarchetypeVersion=3.0
+mvn archetype:generate -DarchetypeGroupId=org.apache.stormcrawler -DarchetypeArtifactId=stormcrawler-archetype -DarchetypeVersion=3.1.0
 ```
 
 You'll be asked to enter a groupId (e.g. com.mycompany.crawler), an artefactId (e.g. stormcrawler), a version, a package name and details about the user agent to use.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Apache StormCrawler (Incubating) is an open source collection of resources for b
 
 ## Quickstart
 
-NOTE: These instructions assume that you have [Apache Maven](https://maven.apache.org/install.html) installed. You will need to install [Apache Storm 2.6.2](http://storm.apache.org/) to run the crawler.
+NOTE: These instructions assume that you have [Apache Maven](https://maven.apache.org/install.html) installed. You will need to install [Apache Storm 3.1.1](http://storm.apache.org/) to run the crawler.
 
 StormCrawler requires Java 11 or above. To execute tests, it requires you to have a locally installed and working Docker environment.
 


### PR DESCRIPTION
Thank you for contributing to Apache StormCrawler.

### For all changes:

- I've updated the archetype Bash example to reflect version 3.1.0 as required.
- I have updated the references for Apache Storm from 3.1.1 to 2.6.4 in the documentation and archetype Bash example as required.

### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
