### PR TITLE
Store metadata as WARC Metadata records

### DIFF
--- a/external/warc/README.md
+++ b/external/warc/README.md
@@ -159,7 +159,7 @@ A note on the recording of HTTP requests and responses with StormCrawler and the
   - the HTTP response headers `Transfer-Encoding`, `Content-Encoding` and `Content-Length` are masked with the prefix `X-Crawler-`
   - a new `Content-Length` header is always appended with the actual payload length.
 
-
+You can specify in the configuration which metadata key/values to store as WARC metadata using `warc.metadata.keys`.
 
 ## Consuming WARC files
 

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/MetadataRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/MetadataRecordFormat.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.stormcrawler.warc;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.lang.StringUtils;
+import org.apache.storm.tuple.Tuple;
+import org.apache.stormcrawler.Metadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+
+Example if metadata record
+https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#example-of-metadata-record
+
+WARC/1.1
+WARC-Type: metadata
+WARC-Target-URI: http://www.archive.org/images/logoc.jpg
+WARC-Date: 2016-09-19T17:20:24Z
+WARC-Record-ID: <urn:uuid:16da6da0-bcdc-49c3-927e-57494593b943>
+WARC-Concurrent-To: <urn:uuid:92283950-ef2f-4d72-b224-f54c6ec90bb0>
+Content-Type: application/warc-fields
+WARC-Block-Digest: sha1:VXT4AF5BBZVHDYKNC2CSM8TEAWDB6CH8
+Content-Length: 59
+
+via: http://www.archive.org/
+hopsFromSeed: E
+fetchTimeMs: 565
+*/
+
+public class MetadataRecordFormat extends WARCRecordFormat {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WARCRequestRecordFormat.class);
+
+    private List<String> metadataKeys;
+
+    public MetadataRecordFormat(List<String> metadataKeys) {
+        super("");
+        this.metadataKeys = metadataKeys;
+    }
+
+    @Override
+    public byte[] format(Tuple tuple) {
+
+        String url = tuple.getStringByField("url");
+        Metadata metadata = (Metadata) tuple.getValueByField("metadata");
+
+        final StringBuilder payload = new StringBuilder();
+
+        // get the metadata key / values to save in the WARCs
+        for (String k : metadataKeys) {
+            // assume a single value for now
+            String value = metadata.getFirstValue(k);
+            if (StringUtils.isBlank(value)) continue;
+            payload.append(k).append(": ").append(value).append(CRLF);
+        }
+
+        // no payload? don't bother
+        if (payload.length() == 0) return new byte[0];
+
+        final byte[] metadata_representation = payload.toString().getBytes(StandardCharsets.UTF_8);
+
+        final StringBuilder buffer = new StringBuilder();
+        buffer.append(WARC_VERSION);
+        buffer.append(CRLF);
+
+        buffer.append("WARC-Type: ").append(WARC_TYPE_METADATA).append(CRLF);
+
+        final String mainID = UUID.randomUUID().toString();
+        buffer.append("WARC-Record-ID: ")
+                .append("<urn:uuid:")
+                .append(mainID)
+                .append(">")
+                .append(CRLF);
+
+        int contentLength = metadata_representation.length;
+        buffer.append("Content-Length: ").append(Integer.toString(contentLength)).append(CRLF);
+
+        String blockDigest = getDigestSha1(metadata_representation);
+
+        String captureTime = getCaptureTime(metadata);
+        buffer.append("WARC-Date: ").append(captureTime).append(CRLF);
+
+        // must be a valid URI
+        try {
+            String normalised = url.replaceAll(" ", "%20");
+            String targetURI = URI.create(normalised).toASCIIString();
+            buffer.append("WARC-Target-URI: ").append(targetURI).append(CRLF);
+        } catch (Exception e) {
+            LOG.warn("Incorrect URI: {}", url);
+            return new byte[] {};
+        }
+
+        buffer.append("Content-Type: application/warc-fields").append(CRLF);
+        buffer.append("WARC-Block-Digest: ").append(blockDigest).append(CRLF);
+
+        byte[] buffAsBytes = buffer.toString().getBytes(StandardCharsets.UTF_8);
+
+        int capacity = 6 + buffAsBytes.length + metadata_representation.length;
+
+        ByteBuffer bytebuffer = ByteBuffer.allocate(capacity);
+        bytebuffer.put(buffAsBytes);
+        bytebuffer.put(CRLF_BYTES);
+        bytebuffer.put(metadata_representation);
+        bytebuffer.put(CRLF_BYTES);
+        bytebuffer.put(CRLF_BYTES);
+
+        return bytebuffer.array();
+    }
+}

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/MetadataRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/MetadataRecordFormat.java
@@ -66,10 +66,10 @@ public class MetadataRecordFormat extends WARCRecordFormat {
 
         // get the metadata key / values to save in the WARCs
         for (String k : metadataKeys) {
-            // assume a single value for now
-            String value = metadata.getFirstValue(k);
-            if (StringUtils.isBlank(value)) continue;
-            payload.append(k).append(": ").append(value).append(CRLF);
+            for (String value : metadata.getValues(k)) {
+                if (StringUtils.isBlank(value)) continue;
+                payload.append(k).append(": ").append(value).append(CRLF);
+            }
         }
 
         // no payload? don't bother

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCHdfsBolt.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCHdfsBolt.java
@@ -19,6 +19,7 @@ package org.apache.stormcrawler.warc;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.fs.Path;
 import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy;
@@ -37,6 +38,8 @@ import org.slf4j.LoggerFactory;
 public class WARCHdfsBolt extends GzipHdfsBolt {
 
     private static final Logger LOG = LoggerFactory.getLogger(WARCHdfsBolt.class);
+
+    private static final String METADATA_KEYS_STORE = "warc.metadata.keys";
 
     private Map<String, String> header_fields = new HashMap<>();
 
@@ -74,6 +77,11 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
         withRecordFormat(new WARCRecordFormat(protocolMDprefix));
         if (withRequestRecords) {
             addRecordFormat(new WARCRequestRecordFormat(protocolMDprefix), 0);
+        }
+        // detect if a list of keys was specified to be stored in the metadata
+        List<String> metadataToWrite = ConfUtils.loadListFromConf(METADATA_KEYS_STORE, conf);
+        if (!metadataToWrite.isEmpty()) {
+            addRecordFormat(new MetadataRecordFormat(metadataToWrite), 1);
         }
     }
 

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
@@ -64,6 +64,8 @@ public class WARCRecordFormat implements RecordFormat {
 
     protected static final String WARC_TYPE_WARCINFO = "warcinfo";
 
+    protected static final String WARC_TYPE_METADATA = "metadata";
+
     protected static final String WARC_VERSION = "WARC/1.0";
     protected static final String CRLF = "\r\n";
     protected static final byte[] CRLF_BYTES = {13, 10};

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
@@ -16,9 +16,7 @@
  */
 package org.apache.stormcrawler.warc;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -287,7 +285,7 @@ class WARCRecordFormatTest {
     @Test
     void testWarcMetadataRecord() {
         Metadata metadata = new Metadata();
-        metadata.addValue("source", "a_source");
+        metadata.addValue("source", "a source");
         metadata.addValues("another", List.of("several", "values"));
         Tuple tuple = mock(Tuple.class);
         when(tuple.getStringByField("url")).thenReturn("https://www.example.org/");
@@ -303,9 +301,10 @@ class WARCRecordFormatTest {
                 warcString.contains("WARC-Type: metadata\r\n"),
                 "WARC record: record type must be \"metadata\"");
         assertTrue(
-                warcString.contains("\r\nsource: a_source\r\n"), "WARC record: missing metadata");
+                warcString.contains("\r\nsource: a source\r\n"), "WARC record: missing metadata");
         assertTrue(
                 warcString.contains("\r\nanother: several\r\n"), "WARC record: missing metadata");
+        assertTrue(warcString.contains("\r\nanother: values\r\n"), "WARC record: missing metadata");
 
         // try to read it with Jwarc
         try (WarcReader reader = new WarcReader(new ByteArrayInputStream(warcBytes))) {
@@ -313,8 +312,9 @@ class WARCRecordFormatTest {
                 assertTrue(record instanceof WarcMetadata, "Can't parse as WARCMetadata");
                 WarcMetadata wmd = (WarcMetadata) record;
                 org.netpreserve.jwarc.MessageHeaders fields = wmd.fields();
-                assertTrue(fields.contains("source", "a_source"));
+                assertTrue(fields.contains("source", "a source"));
                 assertTrue(fields.contains("another", "several"));
+                assertTrue(fields.contains("another", "values"));
             }
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION

The WARC format defines [Metadata records](https://iipc.github.io/warc-specifications/specifications/warc-format/warc-1.1/#example-of-metadata-record). We want to be able to store key values from the Metadata in there, separately from the _response_ records.

Writing these records will be triggered by the presence in the configuration of _warc.metadata.keys_.