### PR TITLE
Fix configuration for Github's linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 *.txt text eol=lf
 *.xml text eol=lf
 *.json text eol=lf
+
+*.html linguist-vendored
+*.flux linguist-vendored


### PR DESCRIPTION
This is minor, but I noticed that Github's linguist assigned HTML as the main language of the repository. This is misleading since all the `.html` files are [test resources](https://github.com/search?q=repo%3Aapache%2Fincubator-stormcrawler++language%3AHTML&type=code). I think the same is true for [FLUX](https://github.com/search?q=repo%3Aapache%2Fincubator-stormcrawler++language%3AFLUX&type=code), since in our context `.flux` files are essentially domain specific YAML files. What do you think?