### PR TITLE
Bugfix nofollow instructions in rel tags ignored

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
@@ -30,6 +30,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.commons.lang.StringUtils;
 import org.apache.storm.metric.api.MultiCountMetric;
 import org.apache.storm.task.OutputCollector;
@@ -269,7 +270,10 @@ public class JSoupParserBolt extends StatusEmitterBolt {
                 final URL baseURL = new URL(url);
                 for (Element link : links) {
                     // nofollow
-                    boolean noFollow = "nofollow".equalsIgnoreCase(link.attr("rel"));
+                    String[] relkeywords = link.attr("rel").split(" ");
+                    boolean noFollow =
+                            Stream.of(relkeywords).anyMatch(x -> x.equalsIgnoreCase("nofollow"));
+
                     // remove altogether
                     if (noFollow && robots_noFollow_strict) {
                         continue;

--- a/core/src/test/resources/digitalpebble.com.html
+++ b/core/src/test/resources/digitalpebble.com.html
@@ -50,6 +50,7 @@ under the License.
 </script>
 
 <a rel="nofollow" href="inexistent.html"/>
+<a rel="nofollow somevalue" href="another_inexistent.html"/>
 
 <body style="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);"
 alink="#000000" link="#000000" vlink="#000000">


### PR DESCRIPTION
... when the tag has more than one value

As specified in [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel)

> the value of the rel attribute, which, if present, must have a value that is an unordered set of unique space-separated keywords.

we currently assume that `nofollow` is the entire value of a `rel` tag and so, if any other keyword is specified, we miss it.

This PR includes a test case and a fix.