### PR TITLE
#1353 Fix for URLFrontier spout not taking into account the crawl ID

### DIFF
--- a/external/urlfrontier/src/main/java/org/apache/stormcrawler/urlfrontier/Constants.java
+++ b/external/urlfrontier/src/main/java/org/apache/stormcrawler/urlfrontier/Constants.java
@@ -42,4 +42,6 @@ public final class Constants {
     public static final String URLFRONTIER_UPDATER_MAX_MESSAGES_KEY =
             "urlfrontier.updater.max.messages";
     public static final String URLFRONTIER_CRAWL_ID_KEY = "urlfrontier.crawlid";
+
+    public static final String URLFRONTIER_ANY_CRAWL_ID = "ANYCRAWL";
 }

--- a/external/urlfrontier/src/main/java/org/apache/stormcrawler/urlfrontier/Constants.java
+++ b/external/urlfrontier/src/main/java/org/apache/stormcrawler/urlfrontier/Constants.java
@@ -42,6 +42,4 @@ public final class Constants {
     public static final String URLFRONTIER_UPDATER_MAX_MESSAGES_KEY =
             "urlfrontier.updater.max.messages";
     public static final String URLFRONTIER_CRAWL_ID_KEY = "urlfrontier.crawlid";
-
-    public static final String URLFRONTIER_ANY_CRAWL_ID = "ANYCRAWL";
 }


### PR DESCRIPTION
Fixes #1353 

The URLFrontier spout will pass the crawl id to GetURLs according to the value of urlfrontier.crawlid

If not set, or equal to "ANYCRAWL"', the crawl ID will not be taken into account in the URLFrontier GetURLs request
(the request will be populated with an AnyCrawlID object which in turn results in a null crawl id on the URLFrontier side).


### For all changes:
- [X] Is there a issue associated with this PR? Is it referenced in the commit message?

- [X] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve? 

- [X] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes:

- [ ] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file?


### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
