### PR TITLE
Fix  #1313 "Exclude "__files" from Source Release Artifacts""

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -1,0 +1,97 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<assembly>
+    <id>source-release</id>
+    <formats>
+        <format>tar.gz</format>
+    </formats>
+    <component>
+        <fileSets>
+            <!-- main project directory structure -->
+            <fileSet>
+                <directory>.</directory>
+                <outputDirectory></outputDirectory>
+                <useDefaultExcludes>true</useDefaultExcludes>
+                <excludes>
+                    <!-- build output -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?${project.build.directory}(/.*)?]</exclude>
+
+                    <!-- NOTE: Most of the following excludes should not be required
+                         if the standard release process is followed. This is because the
+                         release plugin checks out project sources into a location like
+                         target/checkout, then runs the build from there. The result is
+                         a source-release archive that comes from a pretty clean directory
+                         structure.
+
+                         HOWEVER, if the release plugin is configured to run extra goals
+                         or generate a project website, it's definitely possible that some
+                         of these files will be present. So, it's safer to exclude them.
+                    -->
+
+                    <!-- IDEs -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?maven-eclipse\.xml]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.project]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.classpath]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iws]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.idea(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?out(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.ipr]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?[^/]*\.iml]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.settings(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.externalToolBuilders(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.deployables(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.wtpmodules(/.*)?]</exclude>
+
+                    <!-- CI -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.github(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.Jenkinsfile]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.asf\.yaml]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.travis\.yml]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?deploySite\.sh]</exclude>
+
+                    <!-- misc -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?cobertura\.ser]</exclude>
+
+                    <!-- release-plugin temp files -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?pom\.xml\.releaseBackup]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?release\.properties]</exclude>
+
+                    <!-- maven-shade-plugin -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?dependency-reduced-pom\.xml]</exclude>
+
+                    <!-- flatten-maven-plugin -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.flattened-pom\.xml]</exclude>
+
+                    <!-- macOS specific files -->
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?__MACOSX(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?__files(/.*)?]</exclude>
+                    <exclude>%regex[(?!((?!${project.build.directory}/)[^/]+/)*src/)(.*/)?\.DS_Store]</exclude>
+
+                </excludes>
+            </fileSet>
+            <!-- license, readme, etc. calculated at build time -->
+            <fileSet>
+                <directory>${project.build.directory}/maven-shared-archive-resources/META-INF</directory>
+                <outputDirectory></outputDirectory>
+            </fileSet>
+        </fileSets>
+    </component>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -538,15 +538,9 @@ under the License.
 								</goals>
 								<configuration>
 									<finalName>apache-stormcrawler-${project.version}-incubating</finalName>
-									<descriptorRefs>
-										<!--
-                                          There are 3 descriptors available, choose one of them:
-                                          * source-release (zip only, this one is used in the ASF parent POM)
-                                          * source-release-zip-tar (both zip and tar)
-                                          * source-release-tar (tar only)
-                                        -->
-										<descriptorRef>source-release-tar</descriptorRef>
-									</descriptorRefs>
+									<descriptors>
+										<descriptor>assembly.xml</descriptor>
+									</descriptors>
 								</configuration>
 							</execution>
 						</executions>


### PR DESCRIPTION
Thank you for contributing to Apache StormCrawler.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a issue associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve? 

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes:

- [ ] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file?


### Note:
Copy from https://github.com/apache/maven-apache-resources -> added OSX files to list of exclusions.