### PR TITLE
Remove log4j override

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -116,22 +116,6 @@ under the License.
 			<groupId>org.apache.storm</groupId>
 			<artifactId>storm-client</artifactId>
 		</dependency>
-		<!-- dependency overrides for vulnerable log4j versions -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j2.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j2.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j2.version}</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.apache.tika</groupId>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -37,22 +37,6 @@ under the License.
 			<groupId>org.apache.storm</groupId>
 			<artifactId>storm-client</artifactId>
 		</dependency>
-		<!-- dependency overrides for vulnerable log4j versions -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-			<version>${log4j2.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-			<version>${log4j2.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>${log4j2.version}</version>
-		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@ under the License.
 		<tika.version>3.0.0</tika.version>
 		<mockito.version>5.14.2</mockito.version>
 		<jetbrains.annotations.version>26.0.1</jetbrains.annotations.version>
-		<log4j2.version>2.24.3</log4j2.version>
 		<commons.io.version>2.17.0</commons.io.version>
 		<git-code-format-maven-plugin.version>5.3</git-code-format-maven-plugin.version>
 		<testcontainers.version>1.20.4</testcontainers.version>


### PR DESCRIPTION
As discussed previously we can simply remove the log4j override since we depend on the version provided by Storm.