### PR TITLE
#1474 -- catch OpenSearchExceptions to prevent percolation of Runtime…

### DIFF
--- a/external/opensearch/src/main/java/org/apache/stormcrawler/opensearch/IndexCreation.java
+++ b/external/opensearch/src/main/java/org/apache/stormcrawler/opensearch/IndexCreation.java
@@ -85,7 +85,7 @@ public class IndexCreation {
                     client.indices().putTemplate(createIndexRequest, RequestOptions.DEFAULT);
             return createIndexResponse.isAcknowledged();
         } catch (IOException | OpenSearchException e) {
-            log.warn("template not created", e);
+            log.warn("template '{}' not created", templateName, e);
             return false;
         }
     }
@@ -108,7 +108,7 @@ public class IndexCreation {
                     client.indices().create(createIndexRequest, RequestOptions.DEFAULT);
             return createIndexResponse.isAcknowledged();
         } catch (IOException | OpenSearchException e) {
-            log.warn("index not created", e);
+            log.warn("index '{}' not created", indexName, e);
             return false;
         }
     }

--- a/external/opensearch/src/main/java/org/apache/stormcrawler/opensearch/IndexCreation.java
+++ b/external/opensearch/src/main/java/org/apache/stormcrawler/opensearch/IndexCreation.java
@@ -20,7 +20,6 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
-
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.support.master.AcknowledgedResponse;
 import org.opensearch.client.RequestOptions;
@@ -41,10 +40,11 @@ public class IndexCreation {
         final boolean indexExists =
                 client.indices().exists(new GetIndexRequest(indexName), RequestOptions.DEFAULT);
         log.info("Index '{}' exists? {}", indexName, indexExists);
-        //there's a possible check-then-update race condition
-        //createIndex intentionally catches and logs exceptions from OpenSearch
+        // there's a possible check-then-update race condition
+        // createIndex intentionally catches and logs exceptions from OpenSearch
         if (!indexExists) {
-            boolean created = IndexCreation.createIndex(client, indexName, boltType + ".mapping", log);
+            boolean created =
+                    IndexCreation.createIndex(client, indexName, boltType + ".mapping", log);
             log.info("Index '{}' created? {} using {}", indexName, created, boltType + ".mapping");
         }
     }
@@ -58,8 +58,8 @@ public class IndexCreation {
                                 new IndexTemplatesExistRequest(templateName),
                                 RequestOptions.DEFAULT);
         log.info("Template '{}' exists? {}", templateName, templateExists);
-        //there's a possible check-then-update race condition
-        //createTemplate intentionally catches and logs exceptions from OpenSearch
+        // there's a possible check-then-update race condition
+        // createTemplate intentionally catches and logs exceptions from OpenSearch
         if (!templateExists) {
             boolean created =
                     IndexCreation.createTemplate(client, templateName, boltType + ".mapping", log);


### PR DESCRIPTION
…Exceptions, including check-then-update race condition in creating an index.

My guess is that the original intention was to catch everything from the client. However, the client can throw an OpenSearchStatusException which extends OpenSearchException which extends RuntimeException.

This catches and logs problems creating indices and templates.

The initial bug to fix was a "check-the-update" race condition if there are multiple status bolts, for example. This solution may be too broad.

I didn't add a unit test, because I _think_ this is a pretty small fix, and it didn't warrant multithreading the creation of several bolts.

Let me know what you think.

Thank you for contributing to Apache StormCrawler.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a issue associated with this PR? Is it referenced in the commit message?

- [ ] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve? 

- [ ] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes:

- [ ] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [ ] If applicable, have you updated the NOTICE file, including the main NOTICE file?


### Note:
Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.
