### PR TITLE
#621 Async queries in Solr

### DIFF
--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/SolrConnection.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/SolrConnection.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -106,7 +107,7 @@ public class SolrConnection {
             cloud = true;
 
             CloudHttp2SolrClient.Builder builder =
-                    new CloudHttp2SolrClient.Builder(Collections.singletonList(zkHost));
+                    new CloudHttp2SolrClient.Builder(Collections.singletonList(zkHost), Optional.empty());
 
             if (StringUtils.isNotBlank(collection)) {
                 builder.withDefaultCollection(collection);

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/SolrConnection.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/SolrConnection.java
@@ -17,52 +17,127 @@
 package org.apache.stormcrawler.solr;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.CloudHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.ConcurrentUpdateHttp2SolrClient;
 import org.apache.solr.client.solrj.impl.Http2SolrClient;
+import org.apache.solr.client.solrj.impl.LBHttp2SolrClient;
+import org.apache.solr.client.solrj.impl.LBSolrClient;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.cloud.Slice;
+import org.apache.storm.shade.org.apache.commons.lang.StringUtils;
 import org.apache.stormcrawler.util.ConfUtils;
 
 public class SolrConnection {
 
-    private Http2SolrClient client;
-    private ConcurrentUpdateHttp2SolrClient updateClient;
-    
+    private SolrClient client;
+    private SolrClient updateClient;
 
-    private SolrConnection(Http2SolrClient client, ConcurrentUpdateHttp2SolrClient updateClient) {
+    private static boolean cloud;
+    private static String collection;
+
+    private SolrConnection(SolrClient client, SolrClient updateClient) {
         this.client = client;
         this.updateClient = updateClient;
     }
 
-    public Http2SolrClient getClient() {
+    public SolrClient getClient() {
         return client;
     }
 
-    public ConcurrentUpdateHttp2SolrClient getUpdateClient() {
+    public SolrClient getUpdateClient() {
         return updateClient;
     }
 
+    public CompletableFuture<QueryResponse> requestAsync(QueryRequest request) {
+        if (cloud) {
+            CloudHttp2SolrClient cloudHttp2SolrClient = (CloudHttp2SolrClient) client;
+
+            // Get the Solr endpoints
+            Collection<Slice> activeSlices =
+                    cloudHttp2SolrClient
+                            .getClusterState()
+                            .getCollection(collection)
+                            .getActiveSlices();
+
+            List<LBSolrClient.Endpoint> endpoints = new ArrayList<>();
+            for (Slice slice : activeSlices) {
+                for (Replica replica : slice.getReplicas()) {
+                    if (replica.getState() == Replica.State.ACTIVE) {
+                        endpoints.add(new LBSolrClient.Endpoint(replica.getBaseUrl(), collection));
+                    }
+                }
+            }
+
+            // Shuffle the endpoints for basic load balancing
+            Collections.shuffle(endpoints);
+
+            // Get the async client
+            LBHttp2SolrClient lbHttp2SolrClient = cloudHttp2SolrClient.getLbClient();
+            LBSolrClient.Req req = new LBSolrClient.Req(request, endpoints);
+
+            return lbHttp2SolrClient
+                    .requestAsync(req)
+                    .thenApply(rsp -> new QueryResponse(rsp.getResponse(), lbHttp2SolrClient));
+        } else {
+            return ((Http2SolrClient) client)
+                    .requestAsync(request)
+                    .thenApply(nl -> new QueryResponse(nl, client));
+        }
+    }
+
     public static SolrConnection getConnection(Map<String, Object> stormConf, String boltType) {
+        collection = ConfUtils.getString(stormConf, "solr." + boltType + ".collection", null);
+        String zkHost = ConfUtils.getString(stormConf, "solr." + boltType + ".zkhost", null);
 
         String solrUrl = ConfUtils.getString(stormConf, "solr." + boltType + ".url", null);
         int queueSize = ConfUtils.getInt(stormConf, "solr." + boltType + ".queueSize", 100);
 
-        Http2SolrClient http2SolrClient =
-                    new Http2SolrClient.Builder(solrUrl)
-                        .build();
+        if (StringUtils.isNotBlank(zkHost)) {
+            cloud = true;
 
-        ConcurrentUpdateHttp2SolrClient updateClient =
-                new ConcurrentUpdateHttp2SolrClient.Builder(solrUrl, http2SolrClient, true)
-                    .withQueueSize(queueSize)
-                    .build();
+            CloudHttp2SolrClient.Builder builder =
+                    new CloudHttp2SolrClient.Builder(Collections.singletonList(zkHost));
 
-        return new SolrConnection(http2SolrClient, updateClient);
+            if (StringUtils.isNotBlank(collection)) {
+                builder.withDefaultCollection(collection);
+            }
+
+            CloudHttp2SolrClient cloudHttp2SolrClient = builder.build();
+
+            return new SolrConnection(cloudHttp2SolrClient, cloudHttp2SolrClient);
+
+        } else if (StringUtils.isNotBlank(solrUrl)) {
+            cloud = false;
+
+            Http2SolrClient http2SolrClient = new Http2SolrClient.Builder(solrUrl).build();
+
+            ConcurrentUpdateHttp2SolrClient concurrentUpdateHttp2SolrClient =
+                    new ConcurrentUpdateHttp2SolrClient.Builder(solrUrl, http2SolrClient, true)
+                            .withQueueSize(queueSize)
+                            .build();
+
+            return new SolrConnection(http2SolrClient, concurrentUpdateHttp2SolrClient);
+
+        } else {
+            throw new RuntimeException("SolrClient should have zk or solr URL set up");
+        }
     }
 
     public void close() throws IOException, SolrServerException {
-        if (client != null) {
+        if (updateClient != null) {
             client.commit();
-            client.close();
+            updateClient.commit();
+            updateClient.close();
         }
     }
 }

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/bolt/DeletionBolt.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/bolt/DeletionBolt.java
@@ -18,6 +18,7 @@ package org.apache.stormcrawler.solr.bolt;
 
 import java.io.IOException;
 import java.util.Map;
+
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;
@@ -63,7 +64,7 @@ public class DeletionBolt extends BaseRichBolt {
         if (connection != null)
             try {
                 connection.close();
-            } catch (SolrServerException | IOException e) {
+            } catch (IOException | SolrServerException e) {
                 LOG.warn("Failed to close connection", e);
             }
     }
@@ -72,7 +73,7 @@ public class DeletionBolt extends BaseRichBolt {
     public void execute(Tuple tuple) {
         String url = tuple.getStringByField("url");
         try {
-            connection.getClient().deleteById(url);
+            connection.getUpdateClient().deleteById(url);
         } catch (SolrServerException | IOException e) {
             _collector.fail(tuple);
             LOG.error("Exception caught while deleting", e);

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/bolt/DeletionBolt.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/bolt/DeletionBolt.java
@@ -18,7 +18,6 @@ package org.apache.stormcrawler.solr.bolt;
 
 import java.io.IOException;
 import java.util.Map;
-
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.storm.task.OutputCollector;
 import org.apache.storm.task.TopologyContext;

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/bolt/IndexerBolt.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/bolt/IndexerBolt.java
@@ -124,7 +124,7 @@ public class IndexerBolt extends AbstractIndexerBolt {
                 }
             }
 
-            connection.getClient().add(doc);
+            connection.getUpdateClient().add(doc);
 
             eventCounter.scope("Indexed").incrBy(1);
 

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/metrics/MetricsConsumer.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/metrics/MetricsConsumer.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.storm.metric.api.IMetricsConsumer;
 import org.apache.storm.task.IErrorReporter;

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/metrics/MetricsConsumer.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/metrics/MetricsConsumer.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.storm.metric.api.IMetricsConsumer;
 import org.apache.storm.task.IErrorReporter;
@@ -51,7 +52,7 @@ public class MetricsConsumer implements IMetricsConsumer {
 
     @Override
     public void prepare(
-            Map stormConf,
+            Map<String, Object> stormConf,
             Object registrationArgument,
             TopologyContext topologyContext,
             IErrorReporter errorReporter) {
@@ -113,7 +114,7 @@ public class MetricsConsumer implements IMetricsConsumer {
                 doc.addField(ttlField, ttl);
             }
 
-            connection.getClient().add(doc);
+            connection.getUpdateClient().add(doc);
         } catch (Exception e) {
             LOG.error("Problem building a document to Solr", e);
         }

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/SolrSpout.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/SolrSpout.java
@@ -21,14 +21,18 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrQuery.ORDER;
+import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.Group;
 import org.apache.solr.client.solrj.response.GroupCommand;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.util.NamedList;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
 import org.apache.stormcrawler.Metadata;
@@ -179,96 +183,104 @@ public class SolrSpout extends AbstractQueryingSpout {
 
         LOG.debug("QUERY => {}", query);
 
-        try {
-            LOG.trace("isInQuery set to true");
-            isInQuery.set(true);
+        LOG.trace("isInQuery set to true");
+        isInQuery.set(true);
 
-            long startQuery = System.currentTimeMillis();
-            QueryResponse response = connection.getClient().query(query);
-            long endQuery = System.currentTimeMillis();
+        QueryRequest queryRequest = new QueryRequest(query);
+        CompletableFuture<NamedList<Object>> future =  connection.getClient().requestAsync(queryRequest);
 
-            markQueryReceivedNow();
-
-            queryTimes.addMeasurement(endQuery - startQuery);
-
-            SolrDocumentList docs = new SolrDocumentList();
-
-            LOG.debug("Response : {}", response);
-
-            // add the main results
-            if (response.getResults() != null) {
-                docs.addAll(response.getResults());
-            }
-            int groupsTotal = 0;
-            // get groups
-            if (response.getGroupResponse() != null) {
-                for (GroupCommand groupCommand : response.getGroupResponse().getValues()) {
-                    for (Group group : groupCommand.getValues()) {
-                        groupsTotal = Math.max(groupsTotal, group.getResult().size());
-                        LOG.debug("Group : {}", group);
-                        docs.addAll(group.getResult());
-                    }
-                }
-            }
-
-            int numhits =
-                    (response.getResults() != null) ? response.getResults().size() : groupsTotal;
-
-            // no more results?
-            if (numhits == 0) {
-                lastStartOffset = 0;
-                lastNextFetchDate = null;
+        future.whenComplete((futureResponse, throwable) -> {
+            if (throwable != null) {
+                LOG.error("Exception while querying Solr", throwable);
             } else {
-                lastStartOffset += numhits;
+                handleSuccess(futureResponse);
+            }
+        });
+    }
+
+    protected void handleSuccess(NamedList<Object> namedList) {
+
+        QueryResponse response = new QueryResponse(namedList, connection.getClient());
+        long timeTaken = System.currentTimeMillis() - getTimeLastQuerySent();
+
+        markQueryReceivedNow();
+
+        queryTimes.addMeasurement(timeTaken);
+
+        SolrDocumentList docs = new SolrDocumentList();
+
+        LOG.debug("Response : {}", response);
+
+        // add the main results
+        if (response.getResults() != null) {
+            docs.addAll(response.getResults());
+        }
+        int groupsTotal = 0;
+        // get groups
+        if (response.getGroupResponse() != null) {
+            for (GroupCommand groupCommand : response.getGroupResponse().getValues()) {
+                for (Group group : groupCommand.getValues()) {
+                    groupsTotal = Math.max(groupsTotal, group.getResult().size());
+                    LOG.debug("Group : {}", group);
+                    docs.addAll(group.getResult());
+                }
+            }
+        }
+
+        int numhits =
+                (response.getResults() != null) ? response.getResults().size() : groupsTotal;
+
+        // no more results?
+        if (numhits == 0) {
+            lastStartOffset = 0;
+            lastNextFetchDate = null;
+        } else {
+            lastStartOffset += numhits;
+        }
+
+        String prefix = mdPrefix.concat(".");
+
+        int alreadyProcessed = 0;
+        int docReturned = 0;
+
+        for (SolrDocument doc : docs) {
+            String url = (String) doc.get("url");
+
+            docReturned++;
+
+            // is already being processed - skip it!
+            if (beingProcessed.containsKey(url)) {
+                alreadyProcessed++;
+                continue;
             }
 
-            String prefix = mdPrefix.concat(".");
+            Metadata metadata = new Metadata();
 
-            int alreadyProcessed = 0;
-            int docReturned = 0;
+            Iterator<String> keyIterators = doc.getFieldNames().iterator();
+            while (keyIterators.hasNext()) {
+                String key = keyIterators.next();
 
-            for (SolrDocument doc : docs) {
-                String url = (String) doc.get("url");
+                if (key.startsWith(prefix)) {
+                    Collection<Object> values = doc.getFieldValues(key);
 
-                docReturned++;
-
-                // is already being processed - skip it!
-                if (beingProcessed.containsKey(url)) {
-                    alreadyProcessed++;
-                    continue;
-                }
-
-                Metadata metadata = new Metadata();
-
-                Iterator<String> keyIterators = doc.getFieldNames().iterator();
-                while (keyIterators.hasNext()) {
-                    String key = keyIterators.next();
-
-                    if (key.startsWith(prefix)) {
-                        Collection<Object> values = doc.getFieldValues(key);
-
-                        key = key.substring(prefix.length());
-                        Iterator<Object> valueIterator = values.iterator();
-                        while (valueIterator.hasNext()) {
-                            String value = (String) valueIterator.next();
-                            metadata.addValue(key, value);
-                        }
+                    key = key.substring(prefix.length());
+                    Iterator<Object> valueIterator = values.iterator();
+                    while (valueIterator.hasNext()) {
+                        String value = (String) valueIterator.next();
+                        metadata.addValue(key, value);
                     }
                 }
-
-                buffer.add(url, metadata);
             }
 
-            LOG.info(
-                    "SOLR returned {} results from {} buckets in {} msec including {} already being processed",
-                    docReturned,
-                    numhits,
-                    (endQuery - startQuery),
-                    alreadyProcessed);
-
-        } catch (Exception e) {
-            LOG.error("Exception while querying Solr", e);
+            buffer.add(url, metadata);
         }
+
+        LOG.info(
+                "SOLR returned {} results from {} buckets in {} msec including {} already being processed",
+                docReturned,
+                numhits,
+                timeTaken,
+                alreadyProcessed);
     }
 
     @Override

--- a/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/StatusUpdaterBolt.java
+++ b/external/solr/src/main/java/org/apache/stormcrawler/solr/persistence/StatusUpdaterBolt.java
@@ -127,7 +127,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt {
             doc.setField("nextFetchDate", nextFetch.get());
         }
 
-        connection.getClient().add(doc);
+        connection.getUpdateClient().add(doc);
 
         super.ack(t, url);
     }

--- a/external/solr/src/test/java/org/apache/stormcrawler/solr/persistence/IndexerBoltTest.java
+++ b/external/solr/src/test/java/org/apache/stormcrawler/solr/persistence/IndexerBoltTest.java
@@ -70,8 +70,7 @@ public class IndexerBoltTest extends SolrContainerTest {
 
     @After
     public void close() {
-        LOG.info("Closing indexer bolt and Solr container");
-        bolt.cleanup();
+        LOG.info("Closing Solr container");
         container.close();
         output = null;
     }
@@ -111,6 +110,9 @@ public class IndexerBoltTest extends SolrContainerTest {
         index(url, "test", md).get(10, TimeUnit.SECONDS);
 
         assertEquals(1, output.getAckedTuples().size());
+
+        // Flush concurrent update batch
+        bolt.cleanup();
 
         // Make sure the document is indexed in Solr
         SolrClient client = new Http2SolrClient.Builder(getSolrBaseUrl() + "/docs").build();


### PR DESCRIPTION
#621 Support for async queries and batched updates.

Some notes:

- For the Spout, a similar approach to OpenSearch was taken: A separate method handleSuccess processes the response when the async future completes.
- http2 clients were used in all cases.
- For Solr Cloud, using the async client is convoluted and probably against the architecture of CloudSolrClient, but it was the best I could think of. Adding a test seems complicated, so I'll resort to manual testing for now.
- Performance wise, I did not notice major improvements, since the ConcurrentUpdateClient was already in use before and the gains of requestAsync were not major when running locally with limited resources.

Pending tasks:

- [x] Test async method for CloudSolrClient